### PR TITLE
Add Yamls to get Keylime container running on OCP

### DIFF
--- a/deployment/keylime-demo-pv.yaml
+++ b/deployment/keylime-demo-pv.yaml
@@ -1,0 +1,15 @@
+  apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: cgroup-vol
+    labels:
+      type: local
+  spec:
+    storageClassName: manual 
+    capacity:
+      storage: 5Gi
+    accessModes:
+      - ReadWriteMany
+    persistentVolumeReclaimPolicy: Retain
+    hostPath:
+      path: "/sys/fs/cgroup"

--- a/deployment/keylime-demo-pvc.yaml
+++ b/deployment/keylime-demo-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cgroup-vol-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: manual

--- a/deployment/keylimePod.yaml
+++ b/deployment/keylimePod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: keylime-demo
+spec:
+  serviceAccount: keylime
+  serviceAccountName: keylime
+  sercurityContext: 
+    runAsUser: root
+  containers:
+  - name: et-demo
+    image: quay.io/astoycos/et-demo
+    volumeMounts:
+      - mountPath: "/sys/fs/cgroup"
+        name: keylime-claim
+    securityContext:
+      privileged: true
+  nodeSelector: 
+    name: worker1
+  volumes: 
+    - name: keylime-claim
+      persistentVolumeClaim:
+        claimName: cgroup-vol-claim
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for Edge / AI Security Demo
 ##############################################################################
 
-FROM fedora:31
+FROM fedora:latest
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="0.1" description="Dockerfile for Edge / AI Security Demo"
 
@@ -48,6 +48,8 @@ wget \
 keylime \
 which"
 
+RUN dnf -y update -v 
+
 RUN dnf makecache && \
   dnf -y install $PKGS_DEPS && \
   dnf clean all && \
@@ -76,6 +78,8 @@ RUN make && \
   install -c tpm_server /usr/local/bin/tpm_server
 
 VOLUME [ "/sys/fs/cgroup" ]
+
+RUN cd && git clone https://github.com/keylime/keylime
 
 ENTRYPOINT ["/lib/systemd/systemd"]
 


### PR DESCRIPTION
    Includes:
    Persistent Volume Claim yaml 
    Persistent Volume yaml Mounted at the hosts directory "/sys/fs/cgroup"
    Pod Yaml with container mount at "/sys/fs/cgroup"
     - also a placement policy to run on a specified node

    To work the Openshift Project must have PRIVLEDGED SCC permissions

    TODO automate TPM server startup
    Make into a deployment

    Address issue  fix #9 