### PR TITLE
Keylime image now uses systemd to start everything

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile for Edge / AI Security Demo
 ##############################################################################
 
-FROM fedora:latest
+FROM fedora:31
 MAINTAINER Luke Hinds <lhinds@redhat.com>
 LABEL version="0.1" description="Dockerfile for Edge / AI Security Demo"
 
@@ -48,7 +48,7 @@ wget \
 keylime \
 which"
 
-RUN dnf -y update -v 
+RUN dnf -y update -v
 
 RUN dnf makecache && \
   dnf -y install $PKGS_DEPS && \
@@ -79,7 +79,19 @@ RUN make && \
 
 VOLUME [ "/sys/fs/cgroup" ]
 
-RUN cd && git clone https://github.com/keylime/keylime
+# install keylime and have systemd run it at startup
+# have systemd start tpm_server, tpm2-abrmd and keyline-agent
+ADD tpm_server.service /etc/systemd/system/
+RUN chmod 644 /etc/systemd/system/tpm_server.service
+ADD keylime_agent.service /etc/systemd/system/
+RUN chmod 644 /etc/systemd/system/keylime_agent.service
+ADD tpm2-abrmd.service /etc/systemd/system/
+RUN chmod 644 /etc/systemd/system/tpm2-abrmd.service
+
+# configure tpm2-abrmd
+ENV TPM2TOOLS_TCTI "tabrmd:bus_name=com.intel.tss2.Tabrmd"
+
+RUN systemctl enable tpm_server tpm2-abrmd keylime_agent
 
 ENTRYPOINT ["/lib/systemd/systemd"]
 

--- a/docker/keylime_agent.service
+++ b/docker/keylime_agent.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=The Keylime compute agent
+Requires=tpm2-abrmd.service
+
+[Service]
+ExecStart=/usr/bin/keylime_agent
+
+[Install]
+WantedBy=default.target

--- a/docker/tpm2-abrmd.service
+++ b/docker/tpm2-abrmd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=TPM2 Access Broker and Resource Management Daemon
+Requires=tpm_server.service
+
+[Service]
+Type=dbus
+BusName=com.intel.tss2.Tabrmd
+StandardOutput=syslog
+ExecStart=/usr/sbin/tpm2-abrmd --tcti=mssim
+User=tss
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/tpm_server.service
+++ b/docker/tpm_server.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=TPM Server
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/tpm_server -rm


### PR DESCRIPTION
* Add simple tpm_server systemd service file
* Add modified tpm2-abrmd service file that doesn't require things we
  don't use and also depends on tpm_server starting first
* Add modified keylime_agent.service file that depends on tpm2-abrmd
  starting first