### PR TITLE
Adding more systemd service files

### DIFF
--- a/deployment/keylime-controller/keylime_ima_emulator.service
+++ b/deployment/keylime-controller/keylime_ima_emulator.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=The Keylime compute agent
+Description=The Keylime IMA emulator
 Requires=tpm2-abrmd.service
 
 [Service]
-ExecStart=/usr/local/bin/keylime_agent
+ExecStart=/usr/local/bin/keylime_ima_emulator
 Environment=TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd"
 Environment=PYTHONPATH=/home/fedora/keylime
-StandardOutput=append:/var/log/keylime_agent.log
-StandardError=append:/var/log/keylime_agent.log
+StandardOutput=append:/var/log/keylime_ima_emulator.log
+StandardError=append:/var/log/keylime_ima_emulator.log
 
 [Install]
 WantedBy=multi-user.target

--- a/deployment/keylime-controller/keylime_registrar.service
+++ b/deployment/keylime-controller/keylime_registrar.service
@@ -8,4 +8,4 @@ StandardOutput=append:/var/log/keylime_registrar.log
 StandardError=append:/var/log/keylime_registrar.log
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/deployment/keylime-controller/keylime_verifier.service
+++ b/deployment/keylime-controller/keylime_verifier.service
@@ -8,4 +8,4 @@ StandardOutput=append:/var/log/keylime_verifier.log
 StandardError=append:/var/log/keylime_verifier.log
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/deployment/keylime-controller/tpm2-abrmd.service
+++ b/deployment/keylime-controller/tpm2-abrmd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=TPM2 Access Broker and Resource Management Daemon
+After=systemd-udev-settle.service
+
+[Service]
+Type=dbus
+BusName=com.intel.tss2.Tabrmd
+StandardOutput=syslog
+ExecStart=/usr/sbin/tpm2-abrmd --tcti=mssim
+User=tss
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/openshift-worker-nodes/keylime_agent.service
+++ b/deployment/openshift-worker-nodes/keylime_agent.service
@@ -9,4 +9,4 @@ StandardOutput=append:/var/log/keylime_agent.log
 StandardError=append:/var/log/keylime_agent.log
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/deployment/openshift-worker-nodes/keylime_ima_emulator.service
+++ b/deployment/openshift-worker-nodes/keylime_ima_emulator.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=The Keylime IMA emulator
+Requires=tpm2-abrmd.service
+
+[Service]
+ExecStart=/usr/bin/keylime_ima_emulator
+Environment=TPM2TOOLS_TCTI="tabrmd:bus_name=com.intel.tss2.Tabrmd"
+StandardOutput=append:/var/log/keylime_ima_emulator.log
+StandardError=append:/var/log/keylime_ima_emulator.log
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Now all of the background stuff during the demo (tpm_server, tpm2-abrmd,
keylime_ima_emulator, keylime_registrar, keylime_verifier, keylime_agent)
can be run by systemd so you don't have to have it attached to a terminal
and they are easy to restart.

For instance resetting the tpm emulation stuff is just

    systemctl restart tpm_server tpm2-abrmd keylime_ima_emulator

And everything is also logging to /var/log so it's easy to show what's
happening when you need to.